### PR TITLE
Add support for Tree Style Tab addon

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,11 +6,12 @@ function onCreated(n) {
   }
 }
 
-browser.contextMenus.create({
+const menuItemParams = {
   id: "close_left",
   title: browser.i18n.getMessage("contextItemTitle"),
   contexts: ["tab"]
-}, onCreated);
+};
+browser.contextMenus.create(menuItemParams, onCreated);
 
 function closeTabs(sender, tabs) {
     for (var tab of tabs) {
@@ -28,3 +29,28 @@ browser.contextMenus.onClicked.addListener(function(info, sender) {
 
     querying.then(closeTabs.bind(null, sender));
 });
+
+
+// supports Tree Style Tab's fake context menu
+// https://addons.mozilla.org/firefox/addon/tree-style-tab/
+function registerToTST() {
+    browser.runtime.sendMessage("treestyletab@piro.sakura.ne.jp", {
+        type: "fake-contextMenu-create",
+        params: menuItemParams
+    }).then(onCreated, onCreated);
+}
+browser.runtime.onMessageExternal.addListener((message, sender) => {
+    switch (sender.id) {
+        case "treestyletab@piro.sakura.ne.jp":
+            switch (message.type) {
+                case "ready":
+                    registerToTST();
+                    return;
+                case "fake-contextMenu-click":
+                    browser.tabs.query({currentWindow: true})
+                        .then(tabs => closeTabs(message.tab, tabs));
+                    return;
+            }
+    }
+});
+registerToTST();


### PR DESCRIPTION
I hope that the menu item "Close Tabs to Left" added by your addon become available in the sidebar panel of my "Tree Style Tab" addon. How about this?

 * TST provides a simulated context menu on tabs in the sidebar and an API compatible to Firefox's one.
 * After https://bugzilla.mozilla.org/show_bug.cgi?id=1396031 become closed, I'll migrate TST's simulated context menu to the real one, and this change will become needless.